### PR TITLE
Fix the errors of sql.

### DIFF
--- a/src/main/java/org/cinema/config/CreateTable.sql
+++ b/src/main/java/org/cinema/config/CreateTable.sql
@@ -1,38 +1,43 @@
-CREATE TABLE IF NOT EXISTS UserTable
-(firstName varchar(50),
-    lastName varchar(50),
-    username varchar(50)PRIMARY KEY,
-    password varchar(50) )
+CREATE TABLE IF NOT EXISTS person
+(
+    id         serial PRIMARY KEY,
+    first_name varchar(50)        NOT NULL,
+    last_name  varchar(50)        NOT NULL,
+    username   varchar(50) UNIQUE NOT NULL,
+    password   varchar(50)        NOT NULL,
+    role       varchar            NOT NULL -- user or admin
+);
 
-CREATE TABLE IF NOT EXISTS BasketTable
-(id serial ,
-username varchar(50) REFERENCES UserTable(username),
-    idTicke Integer REFERENCES TicketTable(id),
-    filmName varchar(50),
-    numberTicket Integer,
-    priceAll Integer)
+CREATE TABLE IF NOT EXISTS basket
+(
+    id            serial PRIMARY KEY,
+    username      varchar(50) REFERENCES person (username),
+    ticket_id     Integer REFERENCES ticket (id),
+    film_name     varchar(50) REFERENCES ticket (film_name),
+    ticket_number Integer REFERENCES ticket (ticket_number),
+    total_price   Integer NOT NULL
+);
 
-CREATE TABLE IF EXISTS TicketTable
-(id int PRIMARY KEY,
-cinemaName varchar(50),
-    filmName varchar(50),
-    datetime date,
-    clock time,
-    numberTicket int,
-    price int,
-    numberBuy int,
-    CONSTRAIN fk_cinemaName FOREIGNKEY(cinemaName) REFERENCES Cinema (cinemaName))
+CREATE TABLE IF NOT EXISTS ticket
+(
+    id            int PRIMARY KEY,
+    cinema        varchar(50) REFERENCES cinema (cinema),
+    film_name     varchar(50),
+    datetime      date NOT NULL,
+    clock         time NOT NULL,
+    ticket_number int  NOT NULL,
+    price         int  NOT NULL
+);
 
-CREATE TABLE IF NOT EXISTS cinemaTable
-    (cinemaName int PRIMARY KEY,
-    cinemaNumber serial,
-    username varchar(50),
-    password varchar(50),
-    confirm integer )
+CREATE TABLE IF NOT EXISTS cinema
+(
+    id            int PRIMARY KEY NOT NULL,
+    cinema        int             NOT NULL,
+    cinema_number serial          NOT NULL,
+    username      varchar(50)     NOT NULL,
+    password      varchar(50)     NOT NULL,
+    confirm       integer         NOT NULL
 
-CREATE TABLE IF NOT EXISTS AdminTable
-(id serial not null primary key,
-firstName varchar(50),
-lastName varchar(50),
-username varchar(50) not null,
-password varchar(50) not null)
+    -- why should a cinema have a username and password?
+    -- if this username relates to the username defined in the person table, a foreign key must be set here!
+);

--- a/src/main/java/org/cinema/config/CreateTable.sql
+++ b/src/main/java/org/cinema/config/CreateTable.sql
@@ -8,20 +8,23 @@ CREATE TABLE IF NOT EXISTS person
     role       varchar            NOT NULL -- user or admin
 );
 
-CREATE TABLE IF NOT EXISTS basket
+CREATE TABLE IF NOT EXISTS cinema
 (
-    id            serial PRIMARY KEY,
-    username      varchar(50) REFERENCES person (username),
-    ticket_id     Integer REFERENCES ticket (id),
-    film_name     varchar(50) REFERENCES ticket (film_name),
-    ticket_number Integer REFERENCES ticket (ticket_number),
-    total_price   Integer NOT NULL
+    id            serial PRIMARY KEY NOT NULL,
+    cinema        int                NOT NULL,
+    cinema_number serial             NOT NULL,
+    username      varchar(50)        NOT NULL,
+    password      varchar(50)        NOT NULL,
+    confirm       integer            NOT NULL
+
+    -- why should a cinema have a username and password?
+    -- if this username relates to the username defined in the person table, a foreign key must be set here!
 );
 
 CREATE TABLE IF NOT EXISTS ticket
 (
-    id            int PRIMARY KEY,
-    cinema        varchar(50) REFERENCES cinema (cinema),
+    id            serial PRIMARY KEY,
+    cinema_id     serial REFERENCES cinema (id),
     film_name     varchar(50),
     datetime      date NOT NULL,
     clock         time NOT NULL,
@@ -29,15 +32,10 @@ CREATE TABLE IF NOT EXISTS ticket
     price         int  NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS cinema
+CREATE TABLE IF NOT EXISTS basket
 (
-    id            int PRIMARY KEY NOT NULL,
-    cinema        int             NOT NULL,
-    cinema_number serial          NOT NULL,
-    username      varchar(50)     NOT NULL,
-    password      varchar(50)     NOT NULL,
-    confirm       integer         NOT NULL
-
-    -- why should a cinema have a username and password?
-    -- if this username relates to the username defined in the person table, a foreign key must be set here!
+    id          serial PRIMARY KEY,
+    username    varchar(50) REFERENCES person (username),
+    ticket_id   Integer REFERENCES ticket (id),
+    total_price Integer NOT NULL
 );


### PR DESCRIPTION
I made the following changes in this pull request:

1. Merged the `user` table and `admin` table into the `person` table, adding an extra field to indicate the role (which can be `user` or `admin`).

2. Added missing semicolons (`;`) where necessary.

3. Added the `id` field to entities where it was missing.

4. Fixed naming conventions according to the following guidelines:
   - Tables: Table names should be singular and use lowercase letters with underscores between words.
   - Schemas: Schemas should be named with lowercase letters and underscores.

Thanks for your time in reviewing my commit.
